### PR TITLE
Ability to specify an upload path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ module.exports = ({ env }) => ({
         storage_zone: env('BUNNY_STORAGE_ZONE'),
         pull_zone: env('BUNNY_PULL_ZONE'),
         hostname: env('BUNNY_HOSTNAME'),
+        upload_path: env('BUNNY_UPLOAD_PATH'),
       },
     },
   },
@@ -47,6 +48,7 @@ BUNNY_API_KEY: Storage Password (Inside FTP & API Access).
 BUNNY_STORAGE_ZONE: Storage Zone name.
 BUNNY_HOSTNAME: Hostname value (Inside FTP & API Access). eg: ny.storage.bunnycdn.com
 BUNNY_PULL_ZONE: Pull Zone URL.
+BUNNY_UPLOAD_PATH: Upload path, optional.  Should be in the form 'path/subdir' without leading and trailing slashes.
 ```
 
 Enter Pull Zone URL without trailing slash – `https://<pull-zone-name>.b-cdn.net`.\

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-"use strict";Object.defineProperty(exports,"__esModule",{value:!0}),exports.init=void 0;var _utils=require("@strapi/utils"),_axios=_interopRequireDefault(require("axios")),_buffer=require("buffer"),_index=require("./utils/index.js");function _interopRequireDefault(a){return a&&a.__esModule?a:{default:a}}const{ApplicationError}=_utils.errors,init=({api_key:a,storage_zone:b,pull_zone:c,hostname:d})=>{if(!a||!b||!c||!d)throw new ApplicationError("BUNNY_API_KEY, BUNNY_HOSTNAME, BUNNY_STORAGE_ZONE or BUNNY_PULL_ZONE can't be null or undefined.");/**
+"use strict";Object.defineProperty(exports,"__esModule",{value:!0}),exports.init=void 0;var _utils=require("@strapi/utils"),_axios=_interopRequireDefault(require("axios")),_buffer=require("buffer"),_index=require("./utils/index.js");function _interopRequireDefault(a){return a&&a.__esModule?a:{default:a}}const{ApplicationError}=_utils.errors,init=({api_key:a,storage_zone:b,pull_zone:c,hostname:d,upload_path:e})=>{if(!a||!b||!c||!d)throw new ApplicationError("BUNNY_API_KEY, BUNNY_HOSTNAME, BUNNY_STORAGE_ZONE or BUNNY_PULL_ZONE can't be null or undefined.");/**
    * Uploads a file to Bunny CDN.
    *
    * @param {Object} file - The file object to upload.
@@ -6,7 +6,7 @@
    * @param {string} file.hash - The hash of the file.
    * @param {string} file.ext - The file extension.
    * @returns {Promise<void>} A promise that resolves when the file is uploaded.
-   */const e=async e=>{const f=e.stream||_buffer.Buffer.from(e.buffer,"binary");try{const g=await _axios.default.put(`https://${d}/${b}/${e.hash}${e.ext}`,f,{headers:{AccessKey:a,"content-type":"application/octet-stream"}});if(201!==g.data.HttpCode)throw new ApplicationError(`Error uploading to Bunny.net: ${g.data.Message}`);e.url=`https://${c}/${e.hash}${e.ext}`}catch(a){throw new ApplicationError(`Error uploading to Bunny.net: ${a.message}`)}};/**
+   */const f=async f=>{const g=f.stream||_buffer.Buffer.from(f.buffer,"binary"),h=e?`${e}/`:"";try{const e=await _axios.default.put(`https://${d}/${b}/${h}${f.hash}${f.ext}`,g,{headers:{AccessKey:a,"content-type":"application/octet-stream"}});if(201!==e.data.HttpCode)throw new ApplicationError(`Error uploading to Bunny.net: ${e.data.Message}`);f.url=`https://${c}/${h}${f.hash}${f.ext}`}catch(a){throw new ApplicationError(`Error uploading to Bunny.net: ${a.message}`)}};/**
    * Downloads a file from Bunny CDN.
    *
    * @param {Object} file - The file object to download.
@@ -20,8 +20,8 @@
    * @param {string} file.hash - The hash of the file.
    * @param {string} file.ext - The file extension.
    * @returns {Promise<void>} A promise that resolves when the file is deleted.
-   */return{upload:e,download:async c=>{try{const e=await _axios.default.get(`https://${d}/${b}/${c.hash}${c.ext}`,{headers:{AccessKey:a},responseType:"arraybuffer"// Para manejar diferentes tipos de archivos
-}),f=(0,_index.getMimeType)(c.ext);let g;return g=/^text(\/|$)/.test(f)?e.data.toString("utf8"):"application/json"===f?JSON.parse(e.data.toString("utf8")):_buffer.Buffer.from(e.data),{type:f,body:g}}catch(a){throw new ApplicationError(`Error downloading from Bunny.net: ${a.message}`)}},delete:async c=>{try{const e=await _axios.default.delete(`https://${d}/${b}/${c.hash}${c.ext}`,{headers:{AccessKey:a}});200!==e.data.HttpCode&&console.error("Soft Error: Failed to delete file; has it already been deleted?",e.data)}catch(a){console.error("Soft Error: Failed to delete file; has it already been deleted?",a.message)}},uploadStream:e}};/**
+   */return{upload:f,download:async c=>{try{const f=e?`${e}/`:"",g=await _axios.default.get(`https://${d}/${b}/${f}${c.hash}${c.ext}`,{headers:{AccessKey:a},responseType:"arraybuffer"// Para manejar diferentes tipos de archivos
+}),h=(0,_index.getMimeType)(c.ext);let i;return i=/^text(\/|$)/.test(h)?g.data.toString("utf8"):"application/json"===h?JSON.parse(g.data.toString("utf8")):_buffer.Buffer.from(g.data),{type:h,body:i}}catch(a){throw new ApplicationError(`Error downloading from Bunny.net: ${a.message}`)}},delete:async c=>{try{const f=e?`${e}/`:"",g=await _axios.default.delete(`https://${d}/${b}/${f}${c.hash}${c.ext}`,{headers:{AccessKey:a}});200!==g.data.HttpCode&&console.error("Soft Error: Failed to delete file; has it already been deleted?",g.data)}catch(a){console.error("Soft Error: Failed to delete file; has it already been deleted?",a.message)}},uploadStream:f}};/**
  * Initialize Bunny CDN Storage integration.
  *
  * @param {Object} config - The configuration object for Bunny CDN.
@@ -29,5 +29,6 @@
  * @param {string} config.storage_zone - The storage zone name in Bunny CDN.
  * @param {string} config.pull_zone - The pull zone name in Bunny CDN.
  * @param {string} config.hostname - The region of the Bunny CDN storage.
+ * @param {string?} config.upload_path - The default upload path, optional
  * @returns {Object} The initialized upload, download, and delete methods.
  */exports.init=init;


### PR DESCRIPTION
By default strapi will dump files into the root of your storage.  This lets you specify a path.  

It would be nicer if Strapi would do this with the media manager's folders though.  But it's better than nothing.